### PR TITLE
fix: max_results from addon config is ignored in _cache_catalog (#14)

### DIFF
--- a/app/api/stremio.py
+++ b/app/api/stremio.py
@@ -416,7 +416,7 @@ async def _cached_catalog(
             prompt,
             content_type,
             include_adult,
-            settings.MAX_CATALOG_RESULTS,
+            None,
             None,
             False,
         )
@@ -457,7 +457,7 @@ async def _cached_catalog(
         enhanced_prompt,
         content_type,
         include_adult,
-        settings.MAX_CATALOG_RESULTS,
+        None,
         None,
         False,
     )


### PR DESCRIPTION
This pull request makes a small change to the `_cached_catalog` function in `app/api/stremio.py`, replacing the use of `settings.MAX_CATALOG_RESULTS` with `None` for the catalog results limit parameter. This likely allows the downstream function to use its default behavior for result limits.

