### PR TITLE
Add optional SOCKS5h proxy support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       - DEFAULT_MODEL=${DEFAULT_MODEL:-openai/gpt-5-mini:online}
       - TMDB_API_KEY=${TMDB_API_KEY:-}
       - RPDB_API_KEY=${RPDB_API_KEY:-}
+
+      # Optional: Proxy settings
+      # Route all traffic through a SOCKS5h proxy (e.g. WARP container on port 1080)
+      # Useful if server IPs are blocked by TMDB or API Providers.
+      # Uncomment both lines below to enable:
+      # - ALL_PROXY=socks5h://warp:1080
+      # - NO_PROXY=localhost,127.0.0.1
+
     depends_on:
       - redis
     restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 uvicorn[standard]==0.35.0
-httpx==0.28.1
+httpx[socks]==0.28.1
 cryptography==45.0.6
 openai==1.101.0
 pydantic==2.11.7


### PR DESCRIPTION
### Summary
- Added SOCKS5h proxy support via environment variables in docker-compose.yml
- Updated requirements to include httpx[socks]

### Motivation
Some Server IPs are blocked by TMDB or by various LLM API Providers. This allows routing traffic through a SOCKS5h proxy (e.g. Cloudflare WARP) if needed.

### Notes
- Default behavior unchanged if proxy env vars are not set.